### PR TITLE
fix: map completed status to resolved in StatusChart

### DIFF
--- a/components/dashboard/status-chart.tsx
+++ b/components/dashboard/status-chart.tsx
@@ -38,7 +38,11 @@ export function StatusChart({ data }: StatusChartProps) {
   const tFeedback = useTranslations("feedback");
 
   const normalizeStatus = (status: string) =>
-    status === "in_progress" ? "in-progress" : status;
+    status === "in_progress"
+      ? "in-progress"
+      : status === "completed"
+        ? "resolved"
+        : status;
 
   const getStatusLabel = (status: string) => {
     const normalizedStatus = normalizeStatus(status);


### PR DESCRIPTION
## Summary
- update `StatusChart` status normalization to map `completed` to `resolved`
- keep existing `in_progress` -> `in-progress` mapping unchanged
- ensure completed tasks render via resolved color path (green)

## Validation
- `bunx eslint components/dashboard/status-chart.tsx`

Closes #34